### PR TITLE
Session/3 UIViewControllerのライフサイクル

### DIFF
--- a/YumemiTutorial.xcodeproj/project.pbxproj
+++ b/YumemiTutorial.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		185E162D2A2B67B100DBB01C /* YumemiTutorialUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185E162C2A2B67B100DBB01C /* YumemiTutorialUITests.swift */; };
 		185E162F2A2B67B100DBB01C /* YumemiTutorialUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185E162E2A2B67B100DBB01C /* YumemiTutorialUITestsLaunchTests.swift */; };
 		185E163D2A2B6AFF00DBB01C /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = 185E163C2A2B6AFF00DBB01C /* YumemiWeather */; };
+		18BB451A2A34660E00E7C410 /* NewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BB45192A34660E00E7C410 /* NewViewController.swift */; };
+		18BB451C2A34726100E7C410 /* DismissSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BB451B2A34726100E7C410 /* DismissSegue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +52,8 @@
 		185E16282A2B67B100DBB01C /* YumemiTutorialUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = YumemiTutorialUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		185E162C2A2B67B100DBB01C /* YumemiTutorialUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YumemiTutorialUITests.swift; sourceTree = "<group>"; };
 		185E162E2A2B67B100DBB01C /* YumemiTutorialUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YumemiTutorialUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		18BB45192A34660E00E7C410 /* NewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewViewController.swift; sourceTree = "<group>"; };
+		18BB451B2A34726100E7C410 /* DismissSegue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissSegue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +109,8 @@
 				185E160D2A2B67A900DBB01C /* SceneDelegate.swift */,
 				185E160F2A2B67A900DBB01C /* ViewController.swift */,
 				185E16112A2B67A900DBB01C /* Main.storyboard */,
+				18BB451B2A34726100E7C410 /* DismissSegue.swift */,
+				18BB45192A34660E00E7C410 /* NewViewController.swift */,
 				185E16142A2B67B000DBB01C /* Assets.xcassets */,
 				185E16162A2B67B000DBB01C /* LaunchScreen.storyboard */,
 				185E16192A2B67B000DBB01C /* Info.plist */,
@@ -267,8 +273,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				185E16102A2B67A900DBB01C /* ViewController.swift in Sources */,
+				18BB451C2A34726100E7C410 /* DismissSegue.swift in Sources */,
 				185E160C2A2B67A900DBB01C /* AppDelegate.swift in Sources */,
 				185E160E2A2B67A900DBB01C /* SceneDelegate.swift in Sources */,
+				18BB451A2A34660E00E7C410 /* NewViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YumemiTutorial/Base.lproj/Main.storyboard
+++ b/YumemiTutorial/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="diM-Mj-32w">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
@@ -12,28 +12,28 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="YumemiTutorial" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="second" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="ViewController" customModule="YumemiTutorial" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U2T-4a-qt5">
-                                <rect key="frame" x="98.333333333333329" y="317.33333333333331" width="196.33333333333337" height="217.33333333333331"/>
+                                <rect key="frame" x="98.333333333333329" y="282.66666666666669" width="196.33333333333337" height="217.66666666666669"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rdD-FL-Pab">
-                                        <rect key="frame" x="0.0" y="0.0" width="196.33333333333334" height="196.33333333333334"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="196.33333333333334" height="196.66666666666666"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="rdD-FL-Pab" secondAttribute="height" multiplier="1:1" id="wy1-l3-7tT"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ーー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oib-VT-siG">
-                                        <rect key="frame" x="0.0" y="196.33333333333331" width="98.333333333333329" height="21"/>
+                                        <rect key="frame" x="0.0" y="196.66666666666663" width="98.333333333333329" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" name="Blue"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ーー" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Q5-sS-jAc">
-                                        <rect key="frame" x="98.333333333333314" y="196.33333333333331" width="98" height="21"/>
+                                        <rect key="frame" x="98.333333333333314" y="196.66666666666663" width="98" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" name="Red"/>
                                         <nil key="highlightedColor"/>
@@ -55,12 +55,15 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3ir-al-G1k">
-                                <rect key="frame" x="98.333333333333329" y="614.66666666666663" width="196.33333333333337" height="35"/>
+                                <rect key="frame" x="98.333333333333329" y="580.33333333333337" width="196.33333333333337" height="35"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kU3-nZ-rsY">
                                         <rect key="frame" x="0.0" y="0.0" width="98.333333333333329" height="35"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Close"/>
+                                        <connections>
+                                            <segue destination="BYZ-38-t0r" kind="custom" customClass="DismissSegue" customModule="YumemiTutorial" customModuleProvider="target" id="gjn-JB-6dG"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="evg-R2-X5D">
                                         <rect key="frame" x="98.333333333333314" y="0.0" width="98" height="35"/>
@@ -95,6 +98,7 @@
                             <constraint firstItem="3ir-al-G1k" firstAttribute="width" secondItem="6Tk-OE-BBY" secondAttribute="width" multiplier="0.5" id="afC-AC-s9F"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="yub-sp-w5X"/>
                     <connections>
                         <outlet property="weatherImageView" destination="rdD-FL-Pab" id="SCw-vB-0Lc"/>
                     </connections>
@@ -102,6 +106,24 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="133.58778625954199" y="-27.464788732394368"/>
+        </scene>
+        <!--New View Controller-->
+        <scene sceneID="81z-nP-0so">
+            <objects>
+                <viewController storyboardIdentifier="first" useStoryboardIdentifierAsRestorationIdentifier="YES" id="diM-Mj-32w" customClass="NewViewController" customModule="YumemiTutorial" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="UIp-Ma-XuV">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="ejH-gs-laV"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="show" identifier="openWeatherViewSegue" id="wAr-0r-kVE"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="c6u-yo-ZXl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-644" y="-27"/>
         </scene>
     </scenes>
     <resources>

--- a/YumemiTutorial/DismissSegue.swift
+++ b/YumemiTutorial/DismissSegue.swift
@@ -1,0 +1,17 @@
+//
+//  DismissSegue.swift
+//  YumemiTutorial
+//
+//  Created by Apple on 2023/06/10.
+//
+
+import Foundation
+import UIKit
+
+class DismissSegue: UIStoryboardSegue {
+
+    override func perform() {
+        self.source.dismiss(animated: true, completion: nil)
+    }
+
+}

--- a/YumemiTutorial/NewViewController.swift
+++ b/YumemiTutorial/NewViewController.swift
@@ -1,0 +1,19 @@
+//
+//  NewViewController.swift
+//  YumemiTutorial
+//
+//  Created by Apple on 2023/06/10.
+//
+
+import UIKit
+
+class  NewViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    override func viewDidAppear(_ animated: Bool) {
+        self.performSegue(withIdentifier: "openWeatherViewSegue", sender: self)
+    }
+}
+

--- a/YumemiTutorial/SceneDelegate.swift
+++ b/YumemiTutorial/SceneDelegate.swift
@@ -17,6 +17,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
+        
+//        let window = UIWindow(windowScene: scene as! UIWindowScene)
+//        self.window = window
+//        window.makeKeyAndVisible()
+//
+//        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+//        let vc = storyboard.instantiateViewController(identifier: "second")
+//        window.rootViewController = vc
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/YumemiTutorial/SceneDelegate.swift
+++ b/YumemiTutorial/SceneDelegate.swift
@@ -18,13 +18,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
         
-//        let window = UIWindow(windowScene: scene as! UIWindowScene)
-//        self.window = window
-//        window.makeKeyAndVisible()
-//
-//        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-//        let vc = storyboard.instantiateViewController(identifier: "second")
-//        window.rootViewController = vc
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
- 新しい`ViewController`を作成し、初期画面に設定しました
- 新しい`ViewController`のライフサイクルを利用して、`ViewDidAppear`関数を`override`して画面遷移するようにしました
- Closeボタンを押下することで`ViewController`が閉じられるようにしました

[Session3のDocument](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/VC_Lifecycle.md)によると、文章上では上記の実装で仕様を満たしていると思われるのですが、イメージのGIFを見ると

1. Closeボタンを押下する
2. `ViewController`が閉じられる
3. 閉じられたらすぐにまた閉じた`ViewController`に戻ってくる

という実装になっていて、どちらを優先するべきか悩んで一旦文章を優先した実装になっています。